### PR TITLE
Capitalize filename for message module.

### DIFF
--- a/src/executable/PkgBuilder.hs
+++ b/src/executable/PkgBuilder.hs
@@ -129,6 +129,7 @@ buildNewPkgMsgs tools fname =
                             Just i -> err (pkgMsgs !! i)
          names = map ((destDir </>)
                       . flip replaceExtension ".hs"
+                      . cap
                       . takeFileName)
                      pkgMsgs
          gen = generateMsgType pkgHier pkgMsgs'


### PR DESCRIPTION
**Ensure message type names are capitalized** 4f69261988b28ee58fefffde374b63febedb55a2 forgot to capitalize the name of the file.
