### PR TITLE
Add firstThenSecond to Ros.Topic.Util

### DIFF
--- a/Tests/AllTests.hs
+++ b/Tests/AllTests.hs
@@ -1,9 +1,12 @@
 module Main where
 import qualified MsgGen
+import qualified TopicTest
 import Test.Tasty
 
 main :: IO ()
 main = do genTests <- MsgGen.tests
-          defaultMain $
+          defaultMain $ testGroup "roshask" [
             testGroup "roshask executable"
                       [ genTests ]
+            , testGroup "roshask library"
+              [ TopicTest.topicTests]]

--- a/Tests/TopicTest.hs
+++ b/Tests/TopicTest.hs
@@ -1,0 +1,17 @@
+module TopicTest (topicTests) where
+import Test.Tasty
+import Test.Tasty.HUnit
+import Ros.Topic.Util (fromList, toList, topicRate, firstThenSecond)
+import qualified Ros.Topic as Topic
+
+topicTests :: TestTree
+topicTests = testGroup "Topic Tests" [ firstThenSecondTest]
+
+firstThenSecondTest :: TestTree
+firstThenSecondTest = testCase "firstThenSecond" $ do
+  -- Take the tails of the topics so that this test does not depend on
+  -- the order of the forkIO calls in Ros.Topic.Util.(<+>)
+  let t1 = Topic.tail $ topicRate 1000 $ fromList ([1,2 ..] :: [Int])
+      t2 = Topic.tail $ topicRate 100 $ fromList ([1,2..] :: [Int])
+  ls <- toList $ firstThenSecond t1 t2
+  [(10,2),(20,3),(30,4)] @=? take 3 ls

--- a/Tests/TopicTest.hs
+++ b/Tests/TopicTest.hs
@@ -1,17 +1,13 @@
 module TopicTest (topicTests) where
 import Test.Tasty
 import Test.Tasty.HUnit
-import Ros.Topic.Util (fromList, toList, topicRate, firstThenSecond)
-import qualified Ros.Topic as Topic
+import Ros.Topic.Util (fromList, toList, leftThenRight)
 
 topicTests :: TestTree
-topicTests = testGroup "Topic Tests" [ firstThenSecondTest]
+topicTests = testGroup "Topic Tests" [ leftThenRightTest]
 
-firstThenSecondTest :: TestTree
-firstThenSecondTest = testCase "firstThenSecond" $ do
-  -- Take the tails of the topics so that this test does not depend on
-  -- the order of the forkIO calls in Ros.Topic.Util.(<+>)
-  let t1 = Topic.tail $ topicRate 1000 $ fromList ([1,2 ..] :: [Int])
-      t2 = Topic.tail $ topicRate 100 $ fromList ([1,2..] :: [Int])
-  ls <- toList $ firstThenSecond t1 t2
-  [(10,2),(20,3),(30,4)] @=? take 3 ls
+leftThenRightTest :: TestTree
+leftThenRightTest = testCase "leftThenRight" $ do
+  let t = fromList $ zipWith ($) [Left, Right, Right, Left, Left, Right] [1,2..]
+  ls <- toList $ leftThenRight t
+  ([(1,2),(5,6)] :: [(Int,Int)]) @=? take 2 ls

--- a/roshask.cabal
+++ b/roshask.cabal
@@ -1,5 +1,5 @@
 Name:                roshask
-Version:             0.2
+Version:             0.2.1
 Synopsis:            Haskell support for the ROS robotics framework.
 License:             BSD3
 License-file:        LICENSE

--- a/src/Ros/Topic/Util.hs
+++ b/src/Ros/Topic/Util.hs
@@ -195,6 +195,17 @@ bothNew t1 t2 = Topic $ warmup =<< runTopic (t1 <+> t2)
         go (Right _) (r@(Right _), t) = go r =<< runTopic t
         go (Right y) (Left x, t) = return ((x,y), Topic $ warmup =<< runTopic t)
 
+-- |Returns a 'Topic' that produces a new pair every time a value of
+-- first topic produces a new value, followed by a new value from the
+-- second topic. This can be used for sampling the first topic with
+-- the second topic.
+firstThenSecond :: Topic IO a -> Topic IO b -> Topic IO (a,b)
+firstThenSecond t1 t2 = Topic $ warmup =<< runTopic (t1 <+> t2)
+    where warmup (v,t) = go v =<< runTopic t
+          go (Left x) (Right y, t) = return ((x,y), Topic $ warmup =<< runTopic t)
+          go _ (x, t) = go x =<< runTopic t
+
+
 -- |Merge two 'Topic's into one. The items from each component
 -- 'Topic' will be added to the combined 'Topic' as they become
 -- available.

--- a/src/Ros/Topic/Util.hs
+++ b/src/Ros/Topic/Util.hs
@@ -200,11 +200,14 @@ bothNew t1 t2 = Topic $ warmup =<< runTopic (t1 <+> t2)
 -- second topic. This can be used for sampling the first topic with
 -- the second topic.
 firstThenSecond :: Topic IO a -> Topic IO b -> Topic IO (a,b)
-firstThenSecond t1 t2 = Topic $ warmup =<< runTopic (t1 <+> t2)
+firstThenSecond t1 t2 = leftThenRight (t1 <+> t2)
+
+-- |Produces a value when a Left value is followed by a Right value.
+leftThenRight :: (Monad m) => Topic m (Either a b) -> Topic m (a,b)
+leftThenRight t1 = Topic $ warmup =<< runTopic t1
     where warmup (v,t) = go v =<< runTopic t
           go (Left x) (Right y, t) = return ((x,y), Topic $ warmup =<< runTopic t)
           go _ (x, t) = go x =<< runTopic t
-
 
 -- |Merge two 'Topic's into one. The items from each component
 -- 'Topic' will be added to the combined 'Topic' as they become


### PR DESCRIPTION
I created an equivalent function a while ago when I needed to wait for a signal that the PR2 arm had reached its destination before sending the next arm position goal (see [waitFor](https://github.com/rgleichman/uwsensor_demos/blob/master/simple_grab_hs/src/AngleGripper.hs#L330)). I think this is a general and basic enough function that it is worth including in Topic.Util.

The test might rely upon implementation details of Topic timing.

I believe bothNew can be written in terms of firstThenSecond as:
```Haskell
bothNew' :: Topic IO a -> Topic IO b -> Topic IO (a, b)
bothNew' x y = Topic $ do
  (x1, x2) <- tee x
  (y1, y2) <- tee y
  runTopic $ merge (firstThenSecond x1 y1) (swap <$> firstThenSecond y2 x2)
```