### PR TITLE
Experimental message lenses support and new naming scheme.

### DIFF
--- a/roshask.cabal
+++ b/roshask.cabal
@@ -1,5 +1,5 @@
 Name:                roshask
-Version:             0.2.1
+Version:             0.3
 Synopsis:            Haskell support for the ROS robotics framework.
 License:             BSD3
 License-file:        LICENSE
@@ -159,7 +159,8 @@ Executable roshask
   Main-Is:        Main.hs
   Other-modules:  Analysis Gen MD5 Parse PkgInit ResolutionTypes
                   FieldImports Unregister PkgBuilder Types 
-                  Instances.Binary Instances.Storable Instances.NFData
+                  Instances.Binary Instances.Storable
+                  Instances.Lens Instances.NFData
                   Paths_roshask
   Hs-Source-Dirs: src/executable
 

--- a/src/executable/Analysis.hs
+++ b/src/executable/Analysis.hs
@@ -201,8 +201,7 @@ mkFlatType RFloat32      = "P.Float"
 mkFlatType RFloat64      = "P.Double"
 mkFlatType RTime         = "ROSTime"
 mkFlatType RDuration     = "ROSDuration"
-mkFlatType (RUserType t) = qualify . pack . takeFileName . unpack $ t
-    where qualify b = B.concat [b, ".", b]
+mkFlatType (RUserType t) = pack . takeFileName . unpack $ t
 mkFlatType t             = error $ show t ++ " is not a flat type"
 
 -- Given a home package name and a ROS 'MsgType', generate a Haskell

--- a/src/executable/FieldImports.hs
+++ b/src/executable/FieldImports.hs
@@ -46,12 +46,11 @@ typeDependency p m (RFixedArray _ t)    = S.union vectorDeps $
 typeDependency p m (RVarArray t)        = S.union vectorDeps $
                                        typeDependency p m t
 typeDependency _ _ (RUserType "Header") = 
-    S.fromList ["qualified Ros.Std_msgs.Header as Header", 
+    S.fromList ["Ros.Std_msgs.Header",
                 "Ros.Internal.Msg.HeaderSupport"]
 typeDependency p m (RUserType ut)       = if elem ut m
                                           then singleton $ 
-                                               B.concat ["qualified ", p, ut, 
-                                                         " as ", ut]
+                                               B.append p ut
                                           else path2Module ut
 typeDependency _ _ _                    = S.empty
 
@@ -62,10 +61,9 @@ typeDependency _ _ _                    = S.empty
 path2Module :: ByteString -> Set ByteString
 path2Module p 
     | B.elem '/' p = singleton $
-                     B.concat ["qualified Ros.",
-                               B.intercalate "." . map cap $ parts,
-                               " as ", last parts]
+                     B.append "Ros." $
+                              B.intercalate "." . map cap $ parts
     | otherwise    = singleton $
-                     B.concat ["qualified Ros.Std_msgs.", p, " as ", p]
+                     B.append"Ros.Std_msgs." p
     where cap s = B.cons (toUpper (B.head s)) (B.tail s)
           parts = B.split '/' p

--- a/src/executable/Gen.hs
+++ b/src/executable/Gen.hs
@@ -10,6 +10,7 @@ import Types
 import FieldImports
 import Instances.Binary
 import Instances.Storable
+import Instances.Lens
 import MD5
 
 data GenArgs = GenArgs {genExtraImport :: ByteString
@@ -50,6 +51,7 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
      return $ B.concat [ modLine, "\n"
                        , imports
                        , storableImport
+                       , lensImport
                        , if null fDecls
                          then dataSingleton
                          else B.concat [ dataLine
@@ -57,6 +59,7 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
                                        , "\n"
                                        , fieldIndent
                                        , "} deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)\n\n"]
+                       , lensInstance name, "\n\n"
                        , binInst, "\n\n"
                        , storableInstance
                        --, genNFDataInstance msg
@@ -66,8 +69,11 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
                        , cons ]
     where name = shortName msg
           tName = pack $ toUpper (head name) : tail name
-          modLine = B.concat ["{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}\n",
-                              "module ", pkgPath, tName, " where"]
+          modLine = B.concat [ "{-# LANGUAGE OverloadedStrings #-}\n"
+                             , "{-# LANGUAGE DeriveDataTypeable #-}\n"
+                             , "{-# LANGUAGE DeriveGeneric #-}\n"
+                             , "{-# LANGUAGE TemplateHaskell #-}\n"
+                             , "module ", pkgPath, tName, " where"]
           imports = B.concat ["import qualified Prelude as P\n",
                               "import Prelude ((.), (+), (*))\n",
                               "import qualified Data.Typeable as T\n",
@@ -89,13 +95,12 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
 genHasHeader :: Msg -> ByteString
 genHasHeader m = 
     if hasHeader m
-    then let hn = fieldName (head (fields m)) -- The header field name
+    then let hn = B.tail $ fieldName (head (fields m)) -- The header field name
          in B.concat ["instance HasHeader ", pack (shortName m), " where\n",
-                      "  getSequence = Header.seq . ", hn, "\n",
-                      "  getFrame = Header.frame_id . ", hn, "\n",
-                      "  getStamp = Header.stamp . " , hn, "\n",
-                      "  setSequence seq x' = x' { ", hn, 
-                      " = (", hn, " x') { Header.seq = seq } }\n\n"]
+                      "  getSequence = view (", hn, " . headerSeq)\n",
+                      "  getFrame    = view (", hn, " . headerFrame_id)\n",
+                      "  getStamp    = view (", hn, " . headerStamp)\n",
+                      "  setSequence = set  (", hn, " . headerSeq)\n\n"]
     else ""
 
 genDefault :: Msg -> ByteString

--- a/src/executable/Instances/Lens.hs
+++ b/src/executable/Instances/Lens.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- |Generate a Lens instances for ROS msg types.
+module Instances.Lens (lensImport, lensInstance) where
+import Data.ByteString.Char8 (ByteString, pack)
+import qualified Data.ByteString.Char8 as B
+import Types
+
+lensImport :: ByteString
+lensImport = "import Control.Lens\n"
+
+lensInstance :: String -> ByteString
+lensInstance name = B.append "makeLenses ''" (pack name)
+

--- a/src/executable/PkgBuilder.hs
+++ b/src/executable/PkgBuilder.hs
@@ -226,6 +226,7 @@ genMsgCabal pkgPath pkgName =
                   , "                   vector > 0.7,"
                   , "                   time >= 1.1,"
                   , "                   data-default-generics >= 0.3,"
+                  , "                   lens >= 4.11,"
                   , B.concat [ "                   roshask == "
                              , roshaskMajorMinor
                              , if null deps then ""  else "," ]

--- a/src/executable/PkgInit.hs
+++ b/src/executable/PkgInit.hs
@@ -11,7 +11,7 @@ import System.FilePath ((</>))
 import System.Process (system)
 
 import Paths_roshask (version)
-import PkgBuilder (rosPkg2CabalPkg)
+import PkgBuilder (rosPkg2CabalPkg, roshaskMajorMinor)
 
 -- |Initialize a package with the given name in the eponymous
 -- directory with the given ROS package dependencies.
@@ -66,8 +66,11 @@ prepCabal pkgName rosDeps = B.writeFile (pkgName</>(pkgName++".cabal")) $
                    , "  Build-Depends:   base >= 4.2 && < 6,"
                    , "                   vector > 0.7,"
                    , "                   time >= 1.1,"
+                   , "                   lens >= 4.11,"
                    , "                   ROS-rosgraph-msgs,"
-                   , B.append "                   roshask == 0.2.*" moreDeps
+                   , B.concat [ "                   roshask == "
+                              , roshaskMajorMinor
+                              , moreDeps ]
                    , rosDeps
                    , "  GHC-Options:     -O2"
                    , "  Hs-Source-Dirs:  src"

--- a/src/executable/Types.hs
+++ b/src/executable/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |ROS message types.
 module Types (MsgType(..), MsgField(..), MsgConst(..),
-              MsgName, msgName, requestMsgName, responseMsgName,
+              MsgName(..), msgName, requestMsgName, responseMsgName,
               shortName, rawName, fullRosMsgName,
               fullRosSrvName,
               Msg(..), hasHeader, Srv(..),


### PR DESCRIPTION
*This pull request primary for discussion*

Hello! Attached code has a two features.

## New message naming scheme.

### The problem
Currently a lot of generated message has the same record name, for example:
```
data Char = Char { _data :: Int.Int8 ...
data Int64 = Int64 { _data :: Int.Int64 ...
data String = String { _data :: P.String ...
```
Many same names should be qualified by module system, this is a solution. BUT very simple program with 5-7 message types or composit message e.g. PoseStamped makes ugly listing header:
```
import qualified Ros.Std_msgs.Header as Header
import qualified Ros.Geometry_msgs.Point as Point
import qualified Ros.Geometry_msgs.Quaternion as Quaternion
import qualified Ros.Geometry_msgs.Pose as Pose
import qualified Ros.Std_msgs.String as S
...
```

### Composit names
Offered scheme is camelCase composition of message name and row name e.g
```
data Char = Char { charData :: Int.Int8 ...
data Int64 = Int64 { int64Data :: Int.Int64 ...
data String = String { stringData :: P.String ...
```

## Lens(https://github.com/ekmett/lens) support in message generator

The second feature is using lenses as getter/setter of message parts *insead* / together records.

Example:
Increase Z component of Vector3 by 10:
```
runNode "n" $ subscribe "a" >>= advertise "b" . fmap (vector3Z +~ 10)
```

Big profit of this approach presented on big composit messages e.g.
```
runNode "n" $ subscribe "a" >>= advertise "b" . fmap (
    poseStampedPose.posePosition.pointX +~ 10)
```
