### PR TITLE
Lens support in ROS message generator, examples, tests. 

### DIFF
--- a/Examples/AddTwoIntsClient/AddTwoIntsClient.cabal
+++ b/Examples/AddTwoIntsClient/AddTwoIntsClient.cabal
@@ -7,7 +7,7 @@ Build-type:        Custom
 
 Executable AddTwoIntsClient
   Build-Depends:   base >= 4.2 && < 6,
-                   roshask == 0.2.*,
+                   roshask >= 0.2,
                    ROS-rospy-tutorials-msgs
 
   GHC-Options:     -O2

--- a/Examples/AddTwoIntsClient/src/Main.hs
+++ b/Examples/AddTwoIntsClient/src/Main.hs
@@ -4,7 +4,6 @@ import Ros.Service.ServiceTypes
 import Ros.Service (callService)
 import qualified Ros.Rospy_tutorials.AddTwoIntsRequest as Req
 import Ros.Rospy_tutorials.AddTwoIntsResponse as Res
-import Ros.Internal.RosBinary
 
 type Response a = IO (Either ServiceResponseExcept a)
 

--- a/Examples/AddTwoIntsClient/src/Main.hs
+++ b/Examples/AddTwoIntsClient/src/Main.hs
@@ -1,12 +1,16 @@
 module Main (main) where
-import qualified Ros.Rospy_tutorials.AddTwoIntsRequest as Req
-import qualified Ros.Rospy_tutorials.AddTwoIntsResponse as Res
-import Ros.Service (callService)
+
 import Ros.Service.ServiceTypes
+import Ros.Service (callService)
+import qualified Ros.Rospy_tutorials.AddTwoIntsRequest as Req
+import Ros.Rospy_tutorials.AddTwoIntsResponse as Res
+import Ros.Internal.RosBinary
 
 type Response a = IO (Either ServiceResponseExcept a)
 
 main :: IO ()
 main = do
-  response <- callService "/add_two_ints" Req.AddTwoIntsRequest{Req.a=10, Req.b=5} :: Response  Res.AddTwoIntsResponse
-  print response
+  response <- callService "/add_two_ints" Req.AddTwoIntsRequest { Req._a=10, Req._b=5 }
+  case response of
+    Right result -> print (result :: Res.AddTwoIntsResponse)
+    Left  e      -> error (show e)

--- a/Examples/NodeCompose/NodeCompose.cabal
+++ b/Examples/NodeCompose/NodeCompose.cabal
@@ -14,7 +14,7 @@ Executable composition
                  , vector           >  0.7
                  , time             >= 1.1
                  , roshask          >= 0.3
-                 , lens             >= 4.11
+                 , lens-family-core >= 1.2
                  , mtl
                  , ROS-std-msgs
                  , ROS-sensor-msgs

--- a/Examples/NodeCompose/NodeCompose.cabal
+++ b/Examples/NodeCompose/NodeCompose.cabal
@@ -10,13 +10,14 @@ Description: A demonstration of composing two Node values in order to
              telescope and detectUFO with a pointer copy.
 
 Executable composition
-  Build-Depends:   base >= 4.2 && < 6,
-                   vector > 0.7,
-                   time >= 1.1,
-                   roshask == 0.1.*,
-                   mtl,
-                   ROS-std-msgs,
-                   ROS-sensor-msgs
+  Build-Depends:   base             >= 4.2 && < 6
+                 , vector           >  0.7
+                 , time             >= 1.1
+                 , roshask          >= 0.3
+                 , lens             >= 4.11
+                 , mtl
+                 , ROS-std-msgs
+                 , ROS-sensor-msgs
   GHC-Options:     -Odph -threaded
   GHC-Prof-Options:-prof -auto-all -caf-all
   Hs-Source-Dirs:  src
@@ -24,26 +25,28 @@ Executable composition
   Other-Modules:   Telescope DetectUFO
 
 Executable scope
-  Build-Depends:   base >= 4.2 && < 6,
-                   vector > 0.7,
-                   time >= 1.1,
-                   roshask == 0.1.*,
-                   mtl,
-                   ROS-std-msgs,
-                   ROS-sensor-msgs
+  Build-Depends:   base             >= 4.2 && < 6
+                 , vector           >  0.7
+                 , time             >= 1.1
+                 , roshask          >= 0.3
+                 , lens             >= 4.11
+                 , mtl
+                 , ROS-std-msgs
+                 , ROS-sensor-msgs
   GHC-Options:     -Odph -threaded -main-is Telescope
   GHC-Prof-Options:-prof -auto-all -caf-all
   Hs-Source-Dirs:  src
   Main-Is:         Telescope.hs
 
 Executable detect
-  Build-Depends:   base >= 4.2 && < 6,
-                   vector > 0.7,
-                   time >= 1.1,
-                   roshask == 0.1.*,
-                   mtl,
-                   ROS-std-msgs,
-                   ROS-sensor-msgs
+  Build-Depends:   base             >= 4.2 && < 6
+                 , vector           >  0.7
+                 , time             >= 1.1
+                 , roshask          >= 0.3
+                 , lens             >= 4.11
+                 , mtl
+                 , ROS-std-msgs
+                 , ROS-sensor-msgs
   GHC-Options:     -Odph -threaded -main-is DetectUFO
   GHC-Prof-Options:-prof -auto-all -caf-all
   Hs-Source-Dirs:  src

--- a/Examples/NodeCompose/NodeCompose.cabal
+++ b/Examples/NodeCompose/NodeCompose.cabal
@@ -29,7 +29,7 @@ Executable scope
                  , vector           >  0.7
                  , time             >= 1.1
                  , roshask          >= 0.3
-                 , lens             >= 4.11
+                 , lens-family-core >= 1.2
                  , mtl
                  , ROS-std-msgs
                  , ROS-sensor-msgs
@@ -43,7 +43,7 @@ Executable detect
                  , vector           >  0.7
                  , time             >= 1.1
                  , roshask          >= 0.3
-                 , lens             >= 4.11
+                 , lens-family-core >= 1.2
                  , mtl
                  , ROS-std-msgs
                  , ROS-sensor-msgs

--- a/Examples/NodeCompose/src/DetectUFO.hs
+++ b/Examples/NodeCompose/src/DetectUFO.hs
@@ -3,7 +3,7 @@
 -- in a video feed from a sensor.
 module DetectUFO (detectUFO, main) where
 import Ros.Node
-import Control.Lens
+import Lens.Family
 import qualified Data.Vector.Storable as V
 import Data.Word (Word8)
 import Ros.Sensor_msgs.Image

--- a/Examples/NodeCompose/src/DetectUFO.hs
+++ b/Examples/NodeCompose/src/DetectUFO.hs
@@ -3,21 +3,23 @@
 -- in a video feed from a sensor.
 module DetectUFO (detectUFO, main) where
 import Ros.Node
+import Control.Lens
 import qualified Data.Vector.Storable as V
 import Data.Word (Word8)
-import Ros.Sensor_msgs.Image (Image(..), width, height, encoding, _data)
+import Ros.Sensor_msgs.Image
 
 findPt :: Image -> IO ()
-findPt (Image {width, height, encoding, _data})
-  | encoding == "mono8" = maybe noPt showPt p 
+findPt img
+  | img^.encoding == "mono8" = maybe noPt showPt p
   | otherwise = putStrLn "Unsupported image format"
-  where p = V.elemIndex 255 _data
-        toTheta = iatan2 . translate . (`divMod` fi width)
+  where p = V.elemIndex 255 (img^._data)
+        toTheta = iatan2 . translate . (`divMod` fi (img^.width))
         iatan2 (y,x) = atan2 (fromIntegral y) (fromIntegral x) * 180 / pi
         showPt index = putStrLn $ "UFO at angle: " ++ show (toTheta index)
         noPt = putStrLn "Couldn't find UFO"
         fi = fromIntegral
-        translate (y,x) = (y - (fi height `div` 2), x - (fi width `div` 2))
+        translate (y,x) = ( y - (fi (img^.height) `div` 2)
+                          , x - (fi (img^.width)  `div` 2))
 
 detectUFO :: Node ()
 detectUFO = subscribe "video" >>= runHandler findPt >> return ()

--- a/Examples/NodeCompose/src/Telescope.hs
+++ b/Examples/NodeCompose/src/Telescope.hs
@@ -3,7 +3,7 @@
 module Telescope (telescope, main) where
 import Ros.Node
 import Ros.Topic (repeatM)
-import Ros.TopicMT (runTopicState')
+import Ros.Topic.Transformers (runTopicState')
 import Ros.Std_msgs.Header (Header(..))
 import Ros.Sensor_msgs.Image (Image(..))
 import Data.Word (Word8)

--- a/Examples/PubSub/PubSub.cabal
+++ b/Examples/PubSub/PubSub.cabal
@@ -6,22 +6,21 @@ Category:            Robotics
 Build-type:          Custom
 
 Executable talker
-  Build-Depends:  base            >= 4.2 && < 6
-                , vector          >= 0.7
-                , time            >= 1.1
-                , roshask         >= 0.3
-                , lens            >= 4.11
+  Build-Depends:  base             >= 4.2 && < 6
+                , vector           >= 0.7
+                , time             >= 1.1
+                , roshask          >= 0.3
                 , ROS-std-msgs
   GHC-Options:    -Odph -main-is Talker
   Main-Is:        Talker.hs
   Hs-Source-Dirs: src
 
 Executable listener
-  Build-Depends:  base            >= 4.2 && < 6
-                , vector          >= 0.7
-                , time            >= 1.1
-                , roshask         >= 0.3
-                , lens            >= 4.11
+  Build-Depends:  base             >= 4.2 && < 6
+                , vector           >= 0.7
+                , time             >= 1.1
+                , roshask          >= 0.3
+                , lens-family-core >= 1.2
                 , ROS-std-msgs
   GHC-Options:    -Odph -main-is Listener
   Main-Is:        Listener.hs

--- a/Examples/PubSub/PubSub.cabal
+++ b/Examples/PubSub/PubSub.cabal
@@ -6,21 +6,23 @@ Category:            Robotics
 Build-type:          Custom
 
 Executable talker
-  Build-Depends:  base >= 4.2 && < 6,
-                  vector >= 0.7,
-                  time >= 1.1,
-                  roshask == 0.1.*,
-                  ROS-std-msgs
+  Build-Depends:  base            >= 4.2 && < 6
+                , vector          >= 0.7
+                , time            >= 1.1
+                , roshask         >= 0.3
+                , lens            >= 4.11
+                , ROS-std-msgs
   GHC-Options:    -Odph -main-is Talker
   Main-Is:        Talker.hs
   Hs-Source-Dirs: src
 
 Executable listener
-  Build-Depends:  base >= 4.2 && < 6,
-                  vector >= 0.7,
-                  time >= 1.1,
-                  roshask == 0.1.*,
-                  ROS-std-msgs
+  Build-Depends:  base            >= 4.2 && < 6
+                , vector          >= 0.7
+                , time            >= 1.1
+                , roshask         >= 0.3
+                , lens            >= 4.11
+                , ROS-std-msgs
   GHC-Options:    -Odph -main-is Listener
   Main-Is:        Listener.hs
   Hs-Source-Dirs: src

--- a/Examples/PubSub/src/Listener.hs
+++ b/Examples/PubSub/src/Listener.hs
@@ -1,8 +1,9 @@
 module Listener (main) where
 import Ros.Node
+import Control.Lens
 import qualified Ros.Std_msgs.String as S
 
 showMsg :: S.String -> IO ()
-showMsg = putStrLn . ("I heard " ++) . S._data
+showMsg = putStrLn . ("I heard " ++) . view S._data
 
 main = runNode "listener" $ runHandler showMsg =<< subscribe "chatter"

--- a/Examples/PubSub/src/Listener.hs
+++ b/Examples/PubSub/src/Listener.hs
@@ -1,6 +1,6 @@
 module Listener (main) where
 import Ros.Node
-import Control.Lens
+import Lens.Family (view)
 import qualified Ros.Std_msgs.String as S
 
 showMsg :: S.String -> IO ()

--- a/Examples/Turtle/Turtle.cabal
+++ b/Examples/Turtle/Turtle.cabal
@@ -6,36 +6,39 @@ Category:            Robotics
 Build-type:          Custom
 
 Executable Turtle
-  Build-Depends:  base >= 4.2 && < 6,
-                  vector > 0.7,
-                  time >= 1.1,
-                  roshask == 0.1.*,
-                  ROS-std-msgs,
-                  ROS-turtlesim-msgs
+  Build-Depends:  base              >= 4.2 && < 6
+                , vector            >  0.7
+                , time              >= 1.1
+                , roshask           >= 0.3
+                , lens              >= 4.11
+                , data-default-generics
+                , ROS-std-msgs
+                , ROS-geometry-msgs
+                , ROS-turtlesim-msgs
   GHC-Options:    -O2 -main-is Turtle
   Main-Is:        Turtle.hs
   Hs-Source-Dirs: src
 
 Executable Turtle2
-  Build-Depends:  base >= 4.2 && < 6,
-                  vector > 0.7,
-                  time >= 1.1,
-                  roshask == 0.1.*,
-                  vector-space,
-                  ROS-std-msgs,
-                  ROS-turtlesim-msgs
+  Build-Depends:  base              >= 4.2 && < 6
+                , vector            >  0.7
+                , time              >= 1.1
+                , roshask           >= 0.3
+                , vector-space
+                , ROS-std-msgs
+                , ROS-turtlesim-msgs
   GHC-Options:    -O2 -main-is Turtle2
   Main-Is:        Turtle2.hs
   Other-Modules:  AngleNum
   Hs-Source-Dirs: src
 
 Executable Turtle3
-  Build-Depends:  base >= 4.2 && < 6,
-                  vector > 0.7,
-                  time >= 1.1,
-                  roshask == 0.1.*,
-                  ROS-std-msgs,
-                  ROS-turtlesim-msgs
+  Build-Depends:  base              >= 4.2 && < 6
+                , vector            >  0.7
+                , time              >= 1.1
+                , roshask           >= 0.3
+                , ROS-std-msgs
+                , ROS-turtlesim-msgs
   GHC-Options:    -O2 -main-is Turtle3
   Main-Is:        Turtle3.hs
   Other-Modules:  AngleNum

--- a/Examples/Turtle/Turtle.cabal
+++ b/Examples/Turtle/Turtle.cabal
@@ -10,7 +10,7 @@ Executable Turtle
                 , vector            >  0.7
                 , time              >= 1.1
                 , roshask           >= 0.3
-                , lens              >= 4.11
+                , lens-family-core  >= 1.2
                 , data-default-generics
                 , ROS-std-msgs
                 , ROS-geometry-msgs

--- a/Examples/Turtle/manifest.xml
+++ b/Examples/Turtle/manifest.xml
@@ -9,6 +9,7 @@
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/Turtle</url>
   <depend package="std_msgs"/>
+  <depend package="geometry_msgs"/>
   <depend package="turtlesim"/>
 
 </package>

--- a/Examples/Turtle/src/Turtle.hs
+++ b/Examples/Turtle/src/Turtle.hs
@@ -1,13 +1,19 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Turtle (main) where
-import Data.Complex
 import Ros.Node
 import Ros.Topic (cons, repeatM)
-import Ros.TopicUtil (tee, filterBy, everyNew, interruptible, gate, share)
+import Ros.Topic.Util (tee, filterBy, everyNew, interruptible, gate, share)
 import Ros.Turtlesim.Pose
-import Ros.Turtlesim.Velocity
+import Ros.Geometry_msgs.Twist
+import qualified Ros.Geometry_msgs.Vector3 as V
 import Ros.Logging
+
 import System.IO (hFlush, stdout)
+import Data.Default.Generics (def)
+import Control.Applicative ((<$>))
+import Control.Lens ((.~), (^.), (&))
+import Control.Arrow ((&&&))
+import Data.Complex
 
 -- A type synonym for a 2D point.
 type Point = Complex Float
@@ -17,6 +23,11 @@ getTraj :: Topic IO [Point]
 getTraj = repeatM (do putStr "Enter waypoints: " >> hFlush stdout
                       $(logInfo "Waiting for new traj")
                       (map (uncurry (:+)) . read) `fmap` getLine)
+
+-- Create Twist message with linear and angular velocity in arguments.
+mkTwist :: Real a => a -> a -> Twist
+mkTwist l a = def & linear  . V.x .~ realToFrac l
+                  & angular . V.z .~ realToFrac a
 
 wrapAngle theta 
   | theta < 0    = theta + 2 * pi
@@ -29,16 +40,16 @@ angleDiff x y = wrapAngle (x' + pi - y') - pi
 
 -- Produce a unit value every time a goal is reached.
 arrivalTrigger :: Topic IO Point -> Topic IO Pose -> Topic IO ()
-arrivalTrigger goals poses = fmap (const ()) $
-                             filterBy (fmap arrived goals) (fmap p2v poses)
+arrivalTrigger goals poses = const () <$>
+                             filterBy (arrived <$> goals) (p2v <$> poses)
   where arrived goal pose = magnitude (goal - pose) < 1.5
         p2v (Pose x y _ _ _) = x :+ y
 
 -- Navigate to a goal given a current pose estimate.
-navigate :: (Point, Pose) -> Velocity
-navigate (goal, pos) = Velocity (min 2 (magnitude v)) angVel
-  where v        = goal - (x pos :+ y pos)
-        thetaErr = (angleDiff (phase v) (theta pos)) * (180 / pi)
+navigate :: (Point, Pose) -> Twist
+navigate (goal, pos) = mkTwist (min 2 (magnitude v)) angVel
+  where v        = goal - (pos ^. x :+ pos ^. y)
+        thetaErr = (angleDiff (phase v) (pos ^. theta)) * (180 / pi)
         angVel   = signum thetaErr * (min 2 (abs thetaErr))
 
 main = runNode "HaskellBTurtle" $
@@ -46,5 +57,5 @@ main = runNode "HaskellBTurtle" $
           poses <- subscribe "/turtle1/pose"
           (t1,t2) <- liftIO . tee . interruptible $ getTraj
           let goals = gate t1 (cons () (arrivalTrigger t2 poses))
-          advertise "/turtle1/command_velocity" $
+          advertise "/turtle1/cmd_vel" $
                     fmap navigate (everyNew goals poses)

--- a/Examples/Turtle/src/Turtle.hs
+++ b/Examples/Turtle/src/Turtle.hs
@@ -11,8 +11,8 @@ import Ros.Logging
 import System.IO (hFlush, stdout)
 import Data.Default.Generics (def)
 import Control.Applicative ((<$>))
-import Control.Lens ((.~), (^.), (&))
 import Control.Arrow ((&&&))
+import Lens.Family ((.~), (^.), (&))
 import Data.Complex
 
 -- A type synonym for a 2D point.

--- a/Examples/Turtle/src/Turtle2.hs
+++ b/Examples/Turtle/src/Turtle2.hs
@@ -15,7 +15,7 @@ import Ros.Logging
 
 import System.IO (hFlush, stdout)
 import Data.Default.Generics (def)
-import Control.Lens ((.~), (^.), (&))
+import Lens.Family ((.~), (^.), (&))
 import Control.Arrow ((&&&))
 
 -- A type synonym for a 2D point.

--- a/Examples/Turtle/src/Turtle2.hs
+++ b/Examples/Turtle/src/Turtle2.hs
@@ -7,11 +7,16 @@ import Data.Complex
 import AngleNum
 import Ros.Node
 import Ros.Topic (repeatM, force, dropWhile, metamorphM, yieldM)
-import Ros.TopicUtil (everyNew, interruptible)
+import Ros.Topic.Util (everyNew, interruptible)
 import Ros.Turtlesim.Pose
-import Ros.Turtlesim.Velocity
+import Ros.Geometry_msgs.Twist
+import qualified Ros.Geometry_msgs.Vector3 as V
 import Ros.Logging
+
 import System.IO (hFlush, stdout)
+import Data.Default.Generics (def)
+import Control.Lens ((.~), (^.), (&))
+import Control.Arrow ((&&&))
 
 -- A type synonym for a 2D point.
 type Point = Complex Float
@@ -21,6 +26,11 @@ getTraj :: Topic IO [Point]
 getTraj = repeatM (do putStr "Enter waypoints: " >> hFlush stdout
                       $(logInfo "Waiting for new traj")
                       map (uncurry (:+)) . read <$> getLine)
+
+-- Create Twist message with linear and angular velocity in arguments.
+mkTwist :: Real a => a -> a -> Twist
+mkTwist l a = def & linear  . V.x .~ realToFrac l
+                  & angular . V.z .~ realToFrac a
 
 -- Produce a new goal 'Point' every time a goal is reached.
 destinations :: (Functor m, Monad m) => 
@@ -34,20 +44,20 @@ destinations goals poses = metamorphM (start (p2v <$> poses)) goals
 -- Compute linear distance to goal and bearing to goal
 toGoal :: (Pose,Point) -> (Float, Angle Float)
 toGoal (pos,goal) = (magnitude v, angle $ phase v)
-  where v = goal - (x pos :+ y pos)
+  where v = goal - (pos^.x :+ pos^.y)
 
 -- Steer based on a current pose estimate and distance from goal
-steering :: Pose -> (Float, Angle Float) -> Velocity
-steering pos (dpos, thetaDesired) = Velocity (min 2 dpos) angVel
-  where thetaErr = toDegrees $ thetaDesired - angle (theta pos)
+steering :: Pose -> (Float, Angle Float) -> Twist
+steering pos (dpos, thetaDesired) = mkTwist (min 2 dpos) angVel
+  where thetaErr = toDegrees $ thetaDesired - angle (pos^.theta)
         angVel = signum thetaErr * min 2 (abs thetaErr)
 
-navigate :: (Pose, Point) -> Velocity
+navigate :: (Pose, Point) -> Twist
 navigate = uncurry ($) . (steering . fst &&& toGoal)
 
 main = runNode "HaskellBTurtle" $
        do enableLogging (Just Warn)
           poses <- subscribe "/turtle1/pose"
           let goals = destinations (interruptible getTraj) poses
-          advertise "/turtle1/command_velocity" 
+          advertise "/turtle1/cmd_vel" 
                     (navigate <$> everyNew poses goals)

--- a/Examples/Turtle/src/Turtle3.hs
+++ b/Examples/Turtle/src/Turtle3.hs
@@ -8,11 +8,14 @@ import Data.Complex
 import Ros.Logging
 import Ros.Node
 import Ros.Topic (repeatM, force, dropWhile, metamorphM, yieldM)
-import Ros.TopicUtil (everyNew, interruptible, forkTopic, topicOn, subsample)
+import Ros.Topic.Util (everyNew, interruptible, forkTopic, topicOn, subsample)
 import Ros.Util.PID (pidTimedIO)
 import AngleNum
 import Ros.Turtlesim.Pose
-import Ros.Turtlesim.Velocity
+import Ros.Geometry_msgs.Twist
+import qualified Ros.Geometry_msgs.Vector3 as V
+import Data.Default.Generics (def)
+import Control.Lens ((.~), (^.), (&))
 
 -- A type synonym for a 2D point.
 type Point = Complex Float
@@ -22,6 +25,11 @@ getTraj :: Topic IO [Point]
 getTraj = repeatM (do putStr "Enter waypoints: " >> hFlush stdout
                       $(logInfo "Waiting for new traj")
                       map (uncurry (:+)) . read <$> getLine)
+
+-- Create Twist message with linear and angular velocity in arguments.
+mkTwist :: Real a => a -> a -> Twist
+mkTwist l a = def & linear  . V.x .~ realToFrac l
+                  & angular . V.z .~ realToFrac a
 
 -- Produce a new goal 'Point' every time a 'Pose' topic reaches the
 -- vicinity of the previous goal.
@@ -36,17 +44,17 @@ destinations goals poses = metamorphM (start (p2v <$> poses)) goals
 -- Compute linear and angular error to goal.
 toGoal :: (Pose,Point) -> (Float, Float)
 toGoal (pos,goal) = (magnitude v, thetaErr)
-  where v = goal - (x pos :+ y pos)
-        thetaErr = toDegrees $ angle (phase v) - angle (theta pos)
+  where v = goal - (pos ^. x :+ pos ^. y)
+        thetaErr = toDegrees $ angle (phase v) - angle (pos ^. theta)
 
 -- Run a PID loop on angular velocity to converge to a bearing for the
 -- goal.
-steering :: Topic IO (Float,Float) -> Topic IO Velocity
-steering = topicOn snd (Velocity . fst) (($ 0) <$> pidTimedIO 0.01 0.5 0)
+steering :: Topic IO (Float,Float) -> Topic IO Twist
+steering = topicOn snd (mkTwist . fst) (($ 0) <$> pidTimedIO 0.01 0.5 0)
 
 -- Compute position and bearing error to goal, clamp linear and
 -- angular velocities, and generate a steering command.
-navigate :: Topic IO (Pose,Point) -> Topic IO Velocity
+navigate :: Topic IO (Pose,Point) -> Topic IO Twist
 navigate = steering . fmap ((clamp *** id) . toGoal)
   where clamp x = signum x * min 2 (abs x)
 
@@ -55,4 +63,4 @@ main = runNode "HaskellBTurtle" $
           poses <- subscribe "/turtle1/pose"
           let goals = destinations (interruptible getTraj) poses
               commands = subsample 15 $ navigate $ everyNew poses goals
-          advertise "/turtle1/command_velocity" commands
+          advertise "/turtle1/cmd_vel" commands

--- a/Examples/Turtle/src/Turtle3.hs
+++ b/Examples/Turtle/src/Turtle3.hs
@@ -15,7 +15,7 @@ import Ros.Turtlesim.Pose
 import Ros.Geometry_msgs.Twist
 import qualified Ros.Geometry_msgs.Vector3 as V
 import Data.Default.Generics (def)
-import Control.Lens ((.~), (^.), (&))
+import Lens.Family ((.~), (^.), (&))
 
 -- A type synonym for a 2D point.
 type Point = Complex Float

--- a/Tests/MsgGen.hs
+++ b/Tests/MsgGen.hs
@@ -143,8 +143,8 @@ emptySrv = do
     md5 = "d41d8cd98f00b204e9800998ecf8427e"
     testDir = "Tests/test_srvs"
     srvFile = "Tests/test_srvs/srv/Empty.srv"
-    requestFile = "Tests/ServiceClientTests/Ros/Test_srvs/EmptyRequest.hs"
-    responseFile = "Tests/ServiceClientTests/Ros/Test_srvs/EmptyResponse.hs"
+    requestFile = "Tests/test_srvs/golden/EmptyRequest.hs"
+    responseFile = "Tests/test_srvs/golden/EmptyResponse.hs"
 
 -- | ROOT TEST
 

--- a/Tests/actionlib_msgs/golden/GoalID.hs
+++ b/Tests/actionlib_msgs/golden/GoalID.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Actionlib_msgs.GoalID where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -9,13 +12,16 @@ import Ros.Internal.Msg.MsgInfo
 import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import Ros.Internal.RosTypes
+import Control.Lens (makeLenses, view, set)
 
-data GoalID = GoalID { stamp :: ROSTime
-                     , id :: P.String
+data GoalID = GoalID { _stamp :: ROSTime
+                     , _id :: P.String
                      } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''GoalID
+
 instance RosBinary GoalID where
-  put obj' = put (stamp obj') *> put (id obj')
+  put obj' = put (_stamp obj') *> put (_id obj')
   get = GoalID <$> get <*> get
 
 instance MsgInfo GoalID where

--- a/Tests/actionlib_msgs/golden/GoalID.hs
+++ b/Tests/actionlib_msgs/golden/GoalID.hs
@@ -12,13 +12,14 @@ import Ros.Internal.Msg.MsgInfo
 import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import Ros.Internal.RosTypes
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data GoalID = GoalID { _stamp :: ROSTime
                      , _id :: P.String
                      } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''GoalID
+$(makeLenses ''GoalID)
 
 instance RosBinary GoalID where
   put obj' = put (_stamp obj') *> put (_id obj')

--- a/Tests/actionlib_msgs/golden/GoalStatus.hs
+++ b/Tests/actionlib_msgs/golden/GoalStatus.hs
@@ -13,14 +13,15 @@ import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import qualified Data.Word as Word
 import qualified Ros.Actionlib_msgs.GoalID as GoalID
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data GoalStatus = GoalStatus { _goal_id :: GoalID.GoalID
                              , _status :: Word.Word8
                              , _text :: P.String
                              } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''GoalStatus
+$(makeLenses ''GoalStatus)
 
 instance RosBinary GoalStatus where
   put obj' = put (_goal_id obj') *> put (_status obj') *> put (_text obj')

--- a/Tests/actionlib_msgs/golden/GoalStatus.hs
+++ b/Tests/actionlib_msgs/golden/GoalStatus.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Actionlib_msgs.GoalStatus where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -10,14 +13,17 @@ import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import qualified Data.Word as Word
 import qualified Ros.Actionlib_msgs.GoalID as GoalID
+import Control.Lens (makeLenses, view, set)
 
-data GoalStatus = GoalStatus { goal_id :: GoalID.GoalID
-                             , status :: Word.Word8
-                             , text :: P.String
+data GoalStatus = GoalStatus { _goal_id :: GoalID.GoalID
+                             , _status :: Word.Word8
+                             , _text :: P.String
                              } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''GoalStatus
+
 instance RosBinary GoalStatus where
-  put obj' = put (goal_id obj') *> put (status obj') *> put (text obj')
+  put obj' = put (_goal_id obj') *> put (_status obj') *> put (_text obj')
   get = GoalStatus <$> get <*> get <*> get
 
 instance MsgInfo GoalStatus where
@@ -26,33 +32,33 @@ instance MsgInfo GoalStatus where
 
 instance D.Default GoalStatus
 
-pENDING :: Word.Word8
-pENDING = 0
+pending :: Word.Word8
+pending = 0
 
-aCTIVE :: Word.Word8
-aCTIVE = 1
+active :: Word.Word8
+active = 1
 
-pREEMPTED :: Word.Word8
-pREEMPTED = 2
+preempted :: Word.Word8
+preempted = 2
 
-sUCCEEDED :: Word.Word8
-sUCCEEDED = 3
+succeeded :: Word.Word8
+succeeded = 3
 
-aBORTED :: Word.Word8
-aBORTED = 4
+aborted :: Word.Word8
+aborted = 4
 
-rEJECTED :: Word.Word8
-rEJECTED = 5
+rejected :: Word.Word8
+rejected = 5
 
-pREEMPTING :: Word.Word8
-pREEMPTING = 6
+preempting :: Word.Word8
+preempting = 6
 
-rECALLING :: Word.Word8
-rECALLING = 7
+recalling :: Word.Word8
+recalling = 7
 
-rECALLED :: Word.Word8
-rECALLED = 8
+recalled :: Word.Word8
+recalled = 8
 
-lOST :: Word.Word8
-lOST = 9
+lost :: Word.Word8
+lost = 9
 

--- a/Tests/actionlib_msgs/golden/GoalStatusArray.hs
+++ b/Tests/actionlib_msgs/golden/GoalStatusArray.hs
@@ -15,13 +15,14 @@ import Ros.Internal.Msg.HeaderSupport
 import qualified Data.Vector.Storable as V
 import qualified Ros.Actionlib_msgs.GoalStatus as GoalStatus
 import qualified Ros.Std_msgs.Header as Header
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data GoalStatusArray = GoalStatusArray { _header :: Header.Header
                                        , _status_list :: [GoalStatus.GoalStatus]
                                        } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''GoalStatusArray
+$(makeLenses ''GoalStatusArray)
 
 instance RosBinary GoalStatusArray where
   put obj' = put (_header obj') *> putList (_status_list obj')

--- a/Tests/actionlib_msgs/golden/GoalStatusArray.hs
+++ b/Tests/actionlib_msgs/golden/GoalStatusArray.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Actionlib_msgs.GoalStatusArray where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -12,21 +15,24 @@ import Ros.Internal.Msg.HeaderSupport
 import qualified Data.Vector.Storable as V
 import qualified Ros.Actionlib_msgs.GoalStatus as GoalStatus
 import qualified Ros.Std_msgs.Header as Header
+import Control.Lens (makeLenses, view, set)
 
-data GoalStatusArray = GoalStatusArray { header :: Header.Header
-                                       , status_list :: [GoalStatus.GoalStatus]
+data GoalStatusArray = GoalStatusArray { _header :: Header.Header
+                                       , _status_list :: [GoalStatus.GoalStatus]
                                        } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''GoalStatusArray
+
 instance RosBinary GoalStatusArray where
-  put obj' = put (header obj') *> putList (status_list obj')
+  put obj' = put (_header obj') *> putList (_status_list obj')
   get = GoalStatusArray <$> get <*> getList
   putMsg = putStampedMsg
 
 instance HasHeader GoalStatusArray where
-  getSequence = Header.seq . header
-  getFrame = Header.frame_id . header
-  getStamp = Header.stamp . header
-  setSequence seq x' = x' { header = (header x') { Header.seq = seq } }
+  getSequence = view (header . Header.seq)
+  getFrame    = view (header . Header.frame_id)
+  getStamp    = view (header . Header.stamp)
+  setSequence = set  (header . Header.seq)
 
 instance MsgInfo GoalStatusArray where
   sourceMD5 _ = "8b2b82f13216d0a8ea88bd3af735e619"

--- a/Tests/test_msgs/golden/StringConst.hs
+++ b/Tests/test_msgs/golden/StringConst.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Test_msgs.StringConst where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -8,12 +11,15 @@ import Ros.Internal.RosBinary
 import Ros.Internal.Msg.MsgInfo
 import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
+import Control.Lens (makeLenses, view, set)
 
-data StringConst = StringConst { link_name :: P.String
+data StringConst = StringConst { _link_name :: P.String
                                } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''StringConst
+
 instance RosBinary StringConst where
-  put obj' = put (link_name obj')
+  put obj' = put (_link_name obj')
   get = StringConst <$> get
 
 instance MsgInfo StringConst where
@@ -22,9 +28,9 @@ instance MsgInfo StringConst where
 
 instance D.Default StringConst
 
-rEMOVE_ALL_ATTACHED_OBJECTS :: P.String
-rEMOVE_ALL_ATTACHED_OBJECTS = "\"all\""
+remove_all_attached_objects :: P.String
+remove_all_attached_objects = "\"all\""
 
-eMBEDDED_QUOTES :: P.String
-eMBEDDED_QUOTES = "here \"we\" go"
+embedded_quotes :: P.String
+embedded_quotes = "here \"we\" go"
 

--- a/Tests/test_msgs/golden/StringConst.hs
+++ b/Tests/test_msgs/golden/StringConst.hs
@@ -11,12 +11,13 @@ import Ros.Internal.RosBinary
 import Ros.Internal.Msg.MsgInfo
 import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data StringConst = StringConst { _link_name :: P.String
                                } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''StringConst
+$(makeLenses ''StringConst)
 
 instance RosBinary StringConst where
   put obj' = put (_link_name obj')

--- a/Tests/test_srvs/golden/AddTwoIntsRequest.hs
+++ b/Tests/test_srvs/golden/AddTwoIntsRequest.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Test_srvs.AddTwoIntsRequest where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -12,13 +15,16 @@ import Ros.Internal.Msg.SrvInfo
 import qualified Data.Int as Int
 import Foreign.Storable (Storable(..))
 import qualified Ros.Internal.Util.StorableMonad as SM
+import Control.Lens (makeLenses, view, set)
 
-data AddTwoIntsRequest = AddTwoIntsRequest { a :: Int.Int64
-                                           , b :: Int.Int64
+data AddTwoIntsRequest = AddTwoIntsRequest { _a :: Int.Int64
+                                           , _b :: Int.Int64
                                            } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''AddTwoIntsRequest
+
 instance RosBinary AddTwoIntsRequest where
-  put obj' = put (a obj') *> put (b obj')
+  put obj' = put (_a obj') *> put (_b obj')
   get = AddTwoIntsRequest <$> get <*> get
 
 instance Storable AddTwoIntsRequest where
@@ -27,7 +33,7 @@ instance Storable AddTwoIntsRequest where
   alignment _ = 8
   peek = SM.runStorable (AddTwoIntsRequest <$> SM.peek <*> SM.peek)
   poke ptr' obj' = SM.runStorable store' ptr'
-    where store' = SM.poke (a obj') *> SM.poke (b obj')
+    where store' = SM.poke (_a obj') *> SM.poke (_b obj')
 
 instance MsgInfo AddTwoIntsRequest where
   sourceMD5 _ = "36d09b846be0b371c5f190354dd3153e"

--- a/Tests/test_srvs/golden/AddTwoIntsRequest.hs
+++ b/Tests/test_srvs/golden/AddTwoIntsRequest.hs
@@ -15,13 +15,14 @@ import Ros.Internal.Msg.SrvInfo
 import qualified Data.Int as Int
 import Foreign.Storable (Storable(..))
 import qualified Ros.Internal.Util.StorableMonad as SM
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data AddTwoIntsRequest = AddTwoIntsRequest { _a :: Int.Int64
                                            , _b :: Int.Int64
                                            } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''AddTwoIntsRequest
+$(makeLenses ''AddTwoIntsRequest)
 
 instance RosBinary AddTwoIntsRequest where
   put obj' = put (_a obj') *> put (_b obj')

--- a/Tests/test_srvs/golden/AddTwoIntsResponse.hs
+++ b/Tests/test_srvs/golden/AddTwoIntsResponse.hs
@@ -15,12 +15,13 @@ import Ros.Internal.Msg.SrvInfo
 import qualified Data.Int as Int
 import Foreign.Storable (Storable(..))
 import qualified Ros.Internal.Util.StorableMonad as SM
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data AddTwoIntsResponse = AddTwoIntsResponse { _sum :: Int.Int64
                                              } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
-makeLenses ''AddTwoIntsResponse
+$(makeLenses ''AddTwoIntsResponse)
 
 instance RosBinary AddTwoIntsResponse where
   put obj' = put (_sum obj')

--- a/Tests/test_srvs/golden/AddTwoIntsResponse.hs
+++ b/Tests/test_srvs/golden/AddTwoIntsResponse.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Ros.Test_srvs.AddTwoIntsResponse where
 import qualified Prelude as P
 import Prelude ((.), (+), (*))
@@ -12,12 +15,15 @@ import Ros.Internal.Msg.SrvInfo
 import qualified Data.Int as Int
 import Foreign.Storable (Storable(..))
 import qualified Ros.Internal.Util.StorableMonad as SM
+import Control.Lens (makeLenses, view, set)
 
-data AddTwoIntsResponse = AddTwoIntsResponse { sum :: Int.Int64
+data AddTwoIntsResponse = AddTwoIntsResponse { _sum :: Int.Int64
                                              } deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
 
+makeLenses ''AddTwoIntsResponse
+
 instance RosBinary AddTwoIntsResponse where
-  put obj' = put (sum obj')
+  put obj' = put (_sum obj')
   get = AddTwoIntsResponse <$> get
 
 instance Storable AddTwoIntsResponse where
@@ -25,7 +31,7 @@ instance Storable AddTwoIntsResponse where
   alignment _ = 8
   peek = SM.runStorable (AddTwoIntsResponse <$> SM.peek)
   poke ptr' obj' = SM.runStorable store' ptr'
-    where store' = SM.poke (sum obj')
+    where store' = SM.poke (_sum obj')
 
 instance MsgInfo AddTwoIntsResponse where
   sourceMD5 _ = "b88405221c77b1878a3cbbfff53428d7"

--- a/Tests/test_srvs/golden/EmptyRequest.hs
+++ b/Tests/test_srvs/golden/EmptyRequest.hs
@@ -13,11 +13,10 @@ import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import Ros.Internal.Msg.SrvInfo
 import Foreign.Storable (Storable(..))
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data EmptyRequest = EmptyRequest deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
-
-makeLenses ''EmptyRequest
 
 instance RosBinary EmptyRequest where
   put _  = pure ()

--- a/Tests/test_srvs/golden/EmptyRequest.hs
+++ b/Tests/test_srvs/golden/EmptyRequest.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Ros.Test_srvs.EmptyRequest where
+import qualified Prelude as P
+import Prelude ((.), (+), (*))
+import qualified Data.Typeable as T
+import Control.Applicative
+import Ros.Internal.RosBinary
+import Ros.Internal.Msg.MsgInfo
+import qualified GHC.Generics as G
+import qualified Data.Default.Generics as D
+import Ros.Internal.Msg.SrvInfo
+import Foreign.Storable (Storable(..))
+import Control.Lens (makeLenses, view, set)
+
+data EmptyRequest = EmptyRequest deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
+
+makeLenses ''EmptyRequest
+
+instance RosBinary EmptyRequest where
+  put _  = pure ()
+  get = pure EmptyRequest
+
+instance Storable EmptyRequest where
+  sizeOf _ = 1
+  alignment _ = 1
+  peek _ = pure EmptyRequest
+  poke _ _ = pure ()
+
+instance MsgInfo EmptyRequest where
+  sourceMD5 _ = "d41d8cd98f00b204e9800998ecf8427e"
+  msgTypeName _ = "test_srvs/EmptyRequest"
+
+instance D.Default EmptyRequest
+
+instance SrvInfo EmptyRequest where
+  srvMD5 _ = "d41d8cd98f00b204e9800998ecf8427e"
+  srvTypeName _ = "test_srvs/Empty"
+

--- a/Tests/test_srvs/golden/EmptyResponse.hs
+++ b/Tests/test_srvs/golden/EmptyResponse.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Ros.Test_srvs.EmptyResponse where
+import qualified Prelude as P
+import Prelude ((.), (+), (*))
+import qualified Data.Typeable as T
+import Control.Applicative
+import Ros.Internal.RosBinary
+import Ros.Internal.Msg.MsgInfo
+import qualified GHC.Generics as G
+import qualified Data.Default.Generics as D
+import Ros.Internal.Msg.SrvInfo
+import Foreign.Storable (Storable(..))
+import Control.Lens (makeLenses, view, set)
+
+data EmptyResponse = EmptyResponse deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
+
+makeLenses ''EmptyResponse
+
+instance RosBinary EmptyResponse where
+  put _  = pure ()
+  get = pure EmptyResponse
+
+instance Storable EmptyResponse where
+  sizeOf _ = 1
+  alignment _ = 1
+  peek _ = pure EmptyResponse
+  poke _ _ = pure ()
+
+instance MsgInfo EmptyResponse where
+  sourceMD5 _ = "d41d8cd98f00b204e9800998ecf8427e"
+  msgTypeName _ = "test_srvs/EmptyResponse"
+
+instance D.Default EmptyResponse
+
+instance SrvInfo EmptyResponse where
+  srvMD5 _ = "d41d8cd98f00b204e9800998ecf8427e"
+  srvTypeName _ = "test_srvs/Empty"
+

--- a/Tests/test_srvs/golden/EmptyResponse.hs
+++ b/Tests/test_srvs/golden/EmptyResponse.hs
@@ -13,11 +13,10 @@ import qualified GHC.Generics as G
 import qualified Data.Default.Generics as D
 import Ros.Internal.Msg.SrvInfo
 import Foreign.Storable (Storable(..))
-import Control.Lens (makeLenses, view, set)
+import Lens.Family.TH (makeLenses)
+import Lens.Family (view, set)
 
 data EmptyResponse = EmptyResponse deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)
-
-makeLenses ''EmptyResponse
 
 instance RosBinary EmptyResponse where
   put _  = pure ()

--- a/roshask.cabal
+++ b/roshask.cabal
@@ -1,5 +1,5 @@
 Name:                roshask
-Version:             0.2.1
+Version:             0.3
 Synopsis:            Haskell support for the ROS robotics framework.
 License:             BSD3
 License-file:        LICENSE
@@ -159,7 +159,8 @@ Executable roshask
   Main-Is:        Main.hs
   Other-modules:  Analysis Gen MD5 Parse PkgInit ResolutionTypes
                   FieldImports Unregister PkgBuilder Types 
-                  Instances.Binary Instances.Storable Instances.NFData
+                  Instances.Binary Instances.Storable
+                  Instances.Lens Instances.NFData
                   Paths_roshask
   Hs-Source-Dirs: src/executable
 

--- a/src/executable/Gen.hs
+++ b/src/executable/Gen.hs
@@ -58,8 +58,10 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
                                        , fieldSpecs
                                        , "\n"
                                        , fieldIndent
-                                       , "} deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)\n\n"]
-                       , lensInstance name, "\n\n"
+                                       , "} deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)"
+                                       , "\n\n"
+                                       , lensInstance name
+                                       , "\n\n"]
                        , binInst, "\n\n"
                        , storableInstance
                        --, genNFDataInstance msg

--- a/src/executable/Gen.hs
+++ b/src/executable/Gen.hs
@@ -10,6 +10,7 @@ import Types
 import FieldImports
 import Instances.Binary
 import Instances.Storable
+import Instances.Lens
 import MD5
 
 data GenArgs = GenArgs {genExtraImport :: ByteString
@@ -50,6 +51,7 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
      return $ B.concat [ modLine, "\n"
                        , imports
                        , storableImport
+                       , lensImport
                        , if null fDecls
                          then dataSingleton
                          else B.concat [ dataLine
@@ -57,6 +59,7 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
                                        , "\n"
                                        , fieldIndent
                                        , "} deriving (P.Show, P.Eq, P.Ord, T.Typeable, G.Generic)\n\n"]
+                       , lensInstance name, "\n\n"
                        , binInst, "\n\n"
                        , storableInstance
                        --, genNFDataInstance msg
@@ -66,8 +69,11 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
                        , cons ]
     where name = shortName msg
           tName = pack $ toUpper (head name) : tail name
-          modLine = B.concat ["{-# LANGUAGE OverloadedStrings, DeriveDataTypeable, DeriveGeneric #-}\n",
-                              "module ", pkgPath, tName, " where"]
+          modLine = B.concat [ "{-# LANGUAGE OverloadedStrings #-}\n"
+                             , "{-# LANGUAGE DeriveDataTypeable #-}\n"
+                             , "{-# LANGUAGE DeriveGeneric #-}\n"
+                             , "{-# LANGUAGE TemplateHaskell #-}\n"
+                             , "module ", pkgPath, tName, " where"]
           imports = B.concat ["import qualified Prelude as P\n",
                               "import Prelude ((.), (+), (*))\n",
                               "import qualified Data.Typeable as T\n",
@@ -89,13 +95,12 @@ generateMsgTypeExtraImport (GenArgs {genExtraImport=extraImport, genPkgPath=pkgP
 genHasHeader :: Msg -> ByteString
 genHasHeader m = 
     if hasHeader m
-    then let hn = fieldName (head (fields m)) -- The header field name
+    then let hn = B.tail $ fieldName (head (fields m)) -- The header field name
          in B.concat ["instance HasHeader ", pack (shortName m), " where\n",
-                      "  getSequence = Header.seq . ", hn, "\n",
-                      "  getFrame = Header.frame_id . ", hn, "\n",
-                      "  getStamp = Header.stamp . " , hn, "\n",
-                      "  setSequence seq x' = x' { ", hn, 
-                      " = (", hn, " x') { Header.seq = seq } }\n\n"]
+                      "  getSequence = view (", hn, " . Header.seq)\n",
+                      "  getFrame    = view (", hn, " . Header.frame_id)\n",
+                      "  getStamp    = view (", hn, " . Header.stamp)\n",
+                      "  setSequence = set  (", hn, " . Header.seq)\n\n"]
     else ""
 
 genDefault :: Msg -> ByteString

--- a/src/executable/Instances/Lens.hs
+++ b/src/executable/Instances/Lens.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- |Generate a Lens instances for ROS msg types.
+module Instances.Lens (lensImport, lensInstance) where
+import Data.ByteString.Char8 (ByteString, pack)
+import qualified Data.ByteString.Char8 as B
+import Types
+
+lensImport :: ByteString
+lensImport = "import Control.Lens (makeLenses, view, set)\n"
+
+lensInstance :: String -> ByteString
+lensInstance name = B.append "makeLenses ''" (pack name)
+

--- a/src/executable/Instances/Lens.hs
+++ b/src/executable/Instances/Lens.hs
@@ -6,8 +6,9 @@ import qualified Data.ByteString.Char8 as B
 import Types
 
 lensImport :: ByteString
-lensImport = "import Control.Lens (makeLenses, view, set)\n"
+lensImport = B.concat ["import Lens.Family.TH (makeLenses)\n",
+                       "import Lens.Family (view, set)\n"]
 
 lensInstance :: String -> ByteString
-lensInstance name = B.append "makeLenses ''" (pack name)
+lensInstance name = B.concat ["$(makeLenses ''", pack name, ")"]
 

--- a/src/executable/Parse.hs
+++ b/src/executable/Parse.hs
@@ -107,10 +107,12 @@ mkParser sname lname txt = aux . partitionEithers <$> many (choice fieldParsers)
                            (map buildConst cs)
 
 buildField :: (ByteString, MsgType) -> MsgField
-buildField (name,typ) = MsgField (sanitize name) typ name
+buildField (name,typ) = MsgField fname typ name
+  where fname = B.append "_" $ sanitize name
 
 buildConst :: (ByteString, MsgType, ByteString) -> MsgConst
-buildConst (name,typ,val) = MsgConst (sanitize name) typ val name
+buildConst (name,typ,val) = MsgConst fname typ val name
+  where fname = B.map toLower $ sanitize name
 
 {-
 testMsg :: ByteString

--- a/src/executable/PkgBuilder.hs
+++ b/src/executable/PkgBuilder.hs
@@ -226,6 +226,7 @@ genMsgCabal pkgPath pkgName =
                   , "                   vector > 0.7,"
                   , "                   time >= 1.1,"
                   , "                   data-default-generics >= 0.3,"
+                  , "                   lens >= 4.11,"
                   , B.concat [ "                   roshask == "
                              , roshaskMajorMinor
                              , if null deps then ""  else "," ]

--- a/src/executable/PkgBuilder.hs
+++ b/src/executable/PkgBuilder.hs
@@ -226,7 +226,8 @@ genMsgCabal pkgPath pkgName =
                   , "                   vector > 0.7,"
                   , "                   time >= 1.1,"
                   , "                   data-default-generics >= 0.3,"
-                  , "                   lens >= 4.11,"
+                  , "                   lens-family-core >= 1.2,"
+                  , "                   lens-family-th >= 0.4.1,"
                   , B.concat [ "                   roshask == "
                              , roshaskMajorMinor
                              , if null deps then ""  else "," ]

--- a/src/executable/PkgInit.hs
+++ b/src/executable/PkgInit.hs
@@ -11,7 +11,7 @@ import System.FilePath ((</>))
 import System.Process (system)
 
 import Paths_roshask (version)
-import PkgBuilder (rosPkg2CabalPkg)
+import PkgBuilder (rosPkg2CabalPkg, roshaskMajorMinor)
 
 -- |Initialize a package with the given name in the eponymous
 -- directory with the given ROS package dependencies.
@@ -66,8 +66,11 @@ prepCabal pkgName rosDeps = B.writeFile (pkgName</>(pkgName++".cabal")) $
                    , "  Build-Depends:   base >= 4.2 && < 6,"
                    , "                   vector > 0.7,"
                    , "                   time >= 1.1,"
+                   , "                   lens >= 4.11,"
                    , "                   ROS-rosgraph-msgs,"
-                   , B.append "                   roshask == 0.2.*" moreDeps
+                   , B.concat [ "                   roshask == "
+                              , roshaskMajorMinor
+                              , moreDeps ]
                    , rosDeps
                    , "  GHC-Options:     -O2"
                    , "  Hs-Source-Dirs:  src"

--- a/src/executable/PkgInit.hs
+++ b/src/executable/PkgInit.hs
@@ -66,7 +66,8 @@ prepCabal pkgName rosDeps = B.writeFile (pkgName</>(pkgName++".cabal")) $
                    , "  Build-Depends:   base >= 4.2 && < 6,"
                    , "                   vector > 0.7,"
                    , "                   time >= 1.1,"
-                   , "                   lens >= 4.11,"
+                   , "                   lens-family-core >= 1.2,"
+                   , "                   lens-family-th >= 0.4.1,"
                    , "                   ROS-rosgraph-msgs,"
                    , B.concat [ "                   roshask == "
                               , roshaskMajorMinor


### PR DESCRIPTION
## Lens(https://github.com/ekmett/lens) support in message generator

Feature is using lenses as getter/setter of message parts *insead* / together records. 
Records available with prefix `_`.

Example:
Increase Z component of Vector3 by 10:
```haskell
import qualified Ros.Geometry_msgs.Vector3 as V
main = runNode "n" $ subscribe "a" >>= advertise "b" . fmap (V.z +~ 10)
```

And some example from Turtle:
```haskell
import Ros.Turtlesim.Pose
import Ros.Geometry_msgs.Twist
import qualified Ros.Geometry_msgs.Vector3 as V
-- Create Twist message with linear and angular velocity in arguments.
mkTwist :: Real a => a -> a -> Twist
mkTwist l a = def & linear  . V.x .~ realToFrac l
                  & angular . V.z .~ realToFrac a
```

## Constants in message file
Currently constants have a strange names:
```haskell
aCTIVE :: Word.Word8
aCTIVE = 1
```
may be full lower case is more than usual for Haskell constants?
```haskell
active :: Word.Word8
active = 1
```
In this pull constants in messages is full lower case.