### PR TITLE
Arrows on topics; Subscribe, Advertise and Connect type classes.

### DIFF
--- a/roshask.cabal
+++ b/roshask.cabal
@@ -67,6 +67,7 @@ Library
                        Ros.Topic.PID
                        Ros.Topic.Transformers
                        Ros.Topic.Stamped
+                       Ros.Topic.Arrow
                        Ros.Rate
                        Ros.Internal.DepFinder
                        Ros.Internal.Msg.MsgInfo

--- a/src/Ros/Logging.hs
+++ b/src/Ros/Logging.hs
@@ -83,4 +83,4 @@ enableLogging ll = do xs <- liftIO $ getChanContents rosOutChan
                                      (writeIORef showLevel . printLog)
                                      ll
                       liftIO . writeIORef nodeName =<< getName
-                      advertise "/rosout" (fromList xs)
+                      advertise "/rosout" (fromList xs :: Topic IO Log)

--- a/src/Ros/Topic/Arrow.hs
+++ b/src/Ros/Topic/Arrow.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE FlexibleInstances #-}
+-- |The TopicArrow type and wrappers for Topic operations.
+--
+-- This module provide an arrow interface for Topic computations
+-- alternatively monadic inteface @Ros.Topic@.
+--
+-- /Note/: Many of these operations have the same names as similar
+-- operations in the "Prelude" and @Ros.Topic@. The ambiguity may be resolved
+-- using either qualification (e.g. @import qualified Ros.Topic.Arrow as
+-- A@), an explicit import list, or a @hiding@ clause.
+module Ros.Topic.Arrow where
+
+import Ros.Internal.RosBinary (RosBinary)
+import Ros.Internal.Msg.MsgInfo (MsgInfo)
+import Ros.Node (Node, Topic, TopicName, Subscribe, Advertise,
+                 subscribe, advertise, advertiseBuffered)
+import qualified Ros.Topic.Util as U
+import qualified Ros.Topic as T
+
+import Data.AdditiveGroup (AdditiveGroup)
+import Data.Typeable (Typeable)
+import Data.Foldable (Foldable)
+import Data.Monoid (Monoid)
+
+import Control.Monad.IO.Class
+import Control.Applicative
+import Control.Category
+import Control.Arrow
+
+import Prelude hiding (id, (.))
+
+-- |A @TopicArrow@ type is a map of Topic.
+newtype TopicArrow m a b = TopicArrow
+  { runTopicArrow :: Topic m a -> Topic m b }
+
+-- |@TopicArrow@ is a category
+instance Category (TopicArrow m) where
+  id                          = TopicArrow id
+  TopicArrow f . TopicArrow g = TopicArrow (f . g)
+
+-- |@TopicArrow@ is an arrow
+instance (Functor m, Applicative m) => Arrow (TopicArrow m) where
+  arr                  = TopicArrow . fmap
+  first (TopicArrow f) = TopicArrow $ (\(a, b) -> (,) <$> a <*> b)
+                                      <<< f . (fst <$>) &&& (snd <$>)
+
+-- |Simple Subscribe instance
+instance Subscribe (TopicArrow IO ()) where
+  subscribe n =
+    (TopicArrow . const) <$> subscribe n
+
+-- |Simple Advertise instance
+instance Advertise (TopicArrow IO ()) where
+  advertiseBuffered c n a =
+    let emptyTopic = T.repeatM $ return ()
+     in advertiseBuffered c n $ runTopicArrow a emptyTopic
+
+-- |Connect two ROS topic's by name with an arrow
+class Arrow a => Connect a where
+  connect :: (RosBinary b, MsgInfo b, Typeable b,
+              RosBinary c, MsgInfo c, Typeable c)
+          => TopicName -> TopicName -> a b c -> Node ()
+
+instance Connect (->) where
+  connect a b = connect' a b . linkFn
+
+instance Connect (TopicArrow IO) where
+  connect a b = connect' a b . linkTA
+
+linkFn :: (a -> b) -> Topic IO a -> Topic IO b
+linkFn = fmap
+
+linkTA :: TopicArrow IO a b -> TopicArrow IO () a -> TopicArrow IO () b
+linkTA = (<<<)
+
+connect' :: (Subscribe s, Advertise a,
+             RosBinary b, MsgInfo b, Typeable b,
+             RosBinary c, MsgInfo c, Typeable c)
+         => TopicName -> TopicName -> (s b -> a c) -> Node ()
+connect' n1 n2 f =
+  subscribe n1 >>= advertise n2 . f
+
+--
+-- |@Ros.Topic@ operations wrappers
+--
+
+--break
+
+catMaybes :: Monad m => TopicArrow m (Maybe a) a
+catMaybes = TopicArrow T.catMaybes
+
+cons :: Monad m => a -> TopicArrow m a a
+cons = TopicArrow . T.cons
+
+drop :: Monad m => Int -> TopicArrow m a a
+drop = TopicArrow . T.drop
+
+dropWhile :: Monad m => (a -> Bool) -> TopicArrow m a a
+dropWhile = TopicArrow . T.dropWhile
+
+filter :: Monad m => (a -> Bool) -> TopicArrow m a a
+filter = TopicArrow . T.filter
+
+-- force
+-- forever
+-- head
+-- join
+
+mapM :: (Functor m, Monad m) => (a -> m b) -> TopicArrow m a b
+mapM = TopicArrow . T.mapM
+
+-- mapM_
+
+repeatM :: Monad m => m a -> TopicArrow m () a
+repeatM = TopicArrow . const . T.repeatM
+
+scan :: Monad m => (a -> b -> a) -> a -> TopicArrow m b a
+scan f = TopicArrow . T.scan f
+
+-- showTopic
+-- splitAt
+
+tail :: Monad m => TopicArrow m a a
+tail = TopicArrow T.tail
+
+-- tails
+-- take
+-- takeWhile
+-- take_
+-- uncons
+
+unfold :: Functor m => (b -> m (a, b)) -> b -> TopicArrow m () a
+unfold f = TopicArrow . const . T.unfold f
+
+--
+-- |@Ros.Topic.Util@ operations wrappers
+--
+
+toList :: TopicArrow IO () a -> IO [a]
+toList = U.toList . flip runTopicArrow (T.repeatM (return ()))
+
+fromList :: Monad m => [a] -> TopicArrow m () a
+fromList = TopicArrow . const . U.fromList
+
+-- tee
+-- teeEager
+-- fan
+-- share
+
+topicRate :: (Functor m, MonadIO m) => Double -> TopicArrow m a a
+topicRate = TopicArrow . U.topicRate
+
+-- partition
+
+consecutive :: Monad m => TopicArrow m a (a, a)
+consecutive = TopicArrow U.consecutive
+
+-- <+>
+-- everyNew
+-- bothNew
+-- firstThenSecond
+
+leftThenRight :: Monad m => TopicArrow m (Either a b) (a, b)
+leftThenRight = TopicArrow U.leftThenRight
+
+-- merge
+
+finiteDifference :: (Functor m, Monad m) => (a -> a -> b) -> TopicArrow m a b
+finiteDifference = TopicArrow . U.finiteDifference
+
+
+weightedMeanNormalized :: Monad m =>
+                          n -> n -> (b -> b -> c) -> (n -> a -> b) ->
+                          (c -> a) -> TopicArrow m a a
+weightedMeanNormalized alpha invAlpha plus scale normalize =
+  TopicArrow $ U.weightedMeanNormalized alpha invAlpha plus scale normalize
+
+simpsonsRule :: (Monad m, Fractional n) =>
+                (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+simpsonsRule plus scale = TopicArrow $ U.simpsonsRule plus scale
+
+
+weightedMean :: (Monad m, Num n) =>
+                n -> (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+weightedMean alpha plus scale = weightedMean2 alpha (1 - alpha) plus scale
+
+
+weightedMean2 :: Monad m =>
+                 n -> n -> (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+weightedMean2 alpha invAlpha plus scale =
+  TopicArrow $ U.weightedMean2 alpha invAlpha plus scale
+
+-- filterBy
+-- gate
+
+concats :: (Monad m, Foldable f) => TopicArrow m (f a) a
+concats = TopicArrow U.concats
+
+-- interruptible
+-- forkTopic
+
+slidingWindow :: (Monad m, Monoid a) => Int -> TopicArrow m a a
+slidingWindow = TopicArrow . U.slidingWindow
+
+slidingWindowG :: (Monad m, AdditiveGroup a) => Int -> TopicArrow m a a
+slidingWindowG = TopicArrow . U.slidingWindowG
+
+topicOn :: (Applicative m, Monad m) =>
+           (a -> b) -> (a -> c -> d) -> m (b -> m c) -> TopicArrow m a d
+topicOn proj inj trans = TopicArrow $ U.topicOn proj inj trans
+
+subsample :: Monad m => Int -> TopicArrow m a a
+subsample = TopicArrow . U.subsample

--- a/src/Ros/Topic/Arrow.hs
+++ b/src/Ros/Topic/Arrow.hs
@@ -68,9 +68,11 @@ instance Connect (TopicArrow IO) where
   connect a b = connect' a b . linkTA
 
 linkFn :: (a -> b) -> Topic IO a -> Topic IO b
+{-# INLINE linkFn #-}
 linkFn = fmap
 
 linkTA :: TopicArrow IO a b -> TopicArrow IO () a -> TopicArrow IO () b
+{-# INLINE linkTA #-}
 linkTA = (<<<)
 
 connect' :: (Subscribe s, Advertise a,
@@ -87,18 +89,23 @@ connect' n1 n2 f =
 --break
 
 catMaybes :: Monad m => TopicArrow m (Maybe a) a
+{-# INLINE catMaybes #-}
 catMaybes = TopicArrow T.catMaybes
 
 cons :: Monad m => a -> TopicArrow m a a
+{-# INLINE cons #-}
 cons = TopicArrow . T.cons
 
 drop :: Monad m => Int -> TopicArrow m a a
+{-# INLINE drop #-}
 drop = TopicArrow . T.drop
 
 dropWhile :: Monad m => (a -> Bool) -> TopicArrow m a a
+{-# INLINE dropWhile #-}
 dropWhile = TopicArrow . T.dropWhile
 
 filter :: Monad m => (a -> Bool) -> TopicArrow m a a
+{-# INLINE filter #-}
 filter = TopicArrow . T.filter
 
 -- force
@@ -107,20 +114,24 @@ filter = TopicArrow . T.filter
 -- join
 
 mapM :: (Functor m, Monad m) => (a -> m b) -> TopicArrow m a b
+{-# INLINE mapM #-}
 mapM = TopicArrow . T.mapM
 
 -- mapM_
 
 repeatM :: Monad m => m a -> TopicArrow m () a
+{-# INLINE repeatM #-}
 repeatM = TopicArrow . const . T.repeatM
 
 scan :: Monad m => (a -> b -> a) -> a -> TopicArrow m b a
+{-# INLINE scan #-}
 scan f = TopicArrow . T.scan f
 
 -- showTopic
 -- splitAt
 
 tail :: Monad m => TopicArrow m a a
+{-# INLINE tail #-}
 tail = TopicArrow T.tail
 
 -- tails
@@ -130,6 +141,7 @@ tail = TopicArrow T.tail
 -- uncons
 
 unfold :: Functor m => (b -> m (a, b)) -> b -> TopicArrow m () a
+{-# INLINE unfold #-}
 unfold f = TopicArrow . const . T.unfold f
 
 --
@@ -137,9 +149,11 @@ unfold f = TopicArrow . const . T.unfold f
 --
 
 toList :: TopicArrow IO () a -> IO [a]
+{-# INLINE toList #-}
 toList = U.toList . flip runTopicArrow (T.repeatM (return ()))
 
 fromList :: Monad m => [a] -> TopicArrow m () a
+{-# INLINE fromList #-}
 fromList = TopicArrow . const . U.fromList
 
 -- tee
@@ -148,11 +162,13 @@ fromList = TopicArrow . const . U.fromList
 -- share
 
 topicRate :: (Functor m, MonadIO m) => Double -> TopicArrow m a a
+{-# INLINE topicRate #-}
 topicRate = TopicArrow . U.topicRate
 
 -- partition
 
 consecutive :: Monad m => TopicArrow m a (a, a)
+{-# INLINE consecutive #-}
 consecutive = TopicArrow U.consecutive
 
 -- <+>
@@ -161,32 +177,38 @@ consecutive = TopicArrow U.consecutive
 -- firstThenSecond
 
 leftThenRight :: Monad m => TopicArrow m (Either a b) (a, b)
+{-# INLINE leftThenRight #-}
 leftThenRight = TopicArrow U.leftThenRight
 
 -- merge
 
 finiteDifference :: (Functor m, Monad m) => (a -> a -> b) -> TopicArrow m a b
+{-# INLINE finiteDifference #-}
 finiteDifference = TopicArrow . U.finiteDifference
 
 
 weightedMeanNormalized :: Monad m =>
                           n -> n -> (b -> b -> c) -> (n -> a -> b) ->
                           (c -> a) -> TopicArrow m a a
+{-# INLINE weightedMeanNormalized #-}
 weightedMeanNormalized alpha invAlpha plus scale normalize =
   TopicArrow $ U.weightedMeanNormalized alpha invAlpha plus scale normalize
 
 simpsonsRule :: (Monad m, Fractional n) =>
                 (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+{-# INLINE simpsonsRule #-}
 simpsonsRule plus scale = TopicArrow $ U.simpsonsRule plus scale
 
 
 weightedMean :: (Monad m, Num n) =>
                 n -> (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+{-# INLINE weightedMean #-}
 weightedMean alpha plus scale = weightedMean2 alpha (1 - alpha) plus scale
 
 
 weightedMean2 :: Monad m =>
                  n -> n -> (a -> a -> a) -> (n -> a -> a) -> TopicArrow m a a
+{-# INLINE weightedMean2 #-}
 weightedMean2 alpha invAlpha plus scale =
   TopicArrow $ U.weightedMean2 alpha invAlpha plus scale
 
@@ -194,20 +216,25 @@ weightedMean2 alpha invAlpha plus scale =
 -- gate
 
 concats :: (Monad m, Foldable f) => TopicArrow m (f a) a
+{-# INLINE concats #-}
 concats = TopicArrow U.concats
 
 -- interruptible
 -- forkTopic
 
 slidingWindow :: (Monad m, Monoid a) => Int -> TopicArrow m a a
+{-# INLINE slidingWindow #-}
 slidingWindow = TopicArrow . U.slidingWindow
 
 slidingWindowG :: (Monad m, AdditiveGroup a) => Int -> TopicArrow m a a
+{-# INLINE slidingWindowG #-}
 slidingWindowG = TopicArrow . U.slidingWindowG
 
 topicOn :: (Applicative m, Monad m) =>
            (a -> b) -> (a -> c -> d) -> m (b -> m c) -> TopicArrow m a d
+{-# INLINE topicOn #-}
 topicOn proj inj trans = TopicArrow $ U.topicOn proj inj trans
 
 subsample :: Monad m => Int -> TopicArrow m a a
+{-# INLINE subsample #-}
 subsample = TopicArrow . U.subsample


### PR DESCRIPTION
## Arrows
The arrow(https://www.haskell.org/arrows) on topic is an alternative to monadic ```Ros.Topic``` interface.

Arrows says in terms of message changing, e.g.
```haskell
vectorLen :: TopicArrow m Vector3 Float64
vectorLen = arr (\v -> Float64 $ (v ^. x)^2 + (v ^. y)^2 + (v ^. z)^2)
```

```TopicArrow``` has type:
```haskell
newtype TopicArrow m a b = TopicArrow
  { runTopicArrow :: Topic m a -> Topic m b }
```

A lot of standart topic operations can be written in arrow terms, e.g.
```haskell
import qualified Ros.Topic.Util as U

topicRate :: (Functor m, MonadIO m) => Int -> TopicArrow m a a
topicRate = TopicArrow . U.topicRate
```

## Subscribe, Advertise and Connect type classes

The ```Subscribe``` type class is an abstraction of subscribed types, and have definition:
```haskell
class Subscribe s where
  -- |Subscribe to given topic name
  subscribe :: (RosBinary a, MsgInfo a, Typeable a)
             => TopicName -> Node (s a)
```

The ```Advertise``` type class is an abstraction of advertised types, and have definition:
```haskell
class Advertise a where
  -- |Advertise topic messages with a per-client
  -- transmit buffer of the specified size.
  advertiseBuffered :: (RosBinary b, MsgInfo b, Typeable b)
              => Int -> TopicName -> a b -> Node ()
  -- |Advertise a 'Topic' publishing a stream of values produced in
  -- the 'IO' monad. Fixed buffer size version of @advertiseBuffered@.
  advertise :: (RosBinary b, MsgInfo b, Typeable b)
              => TopicName -> a b -> Node ()
  advertise = advertiseBuffered 1
```

The ```Connect``` type class is a combination of ```Subscribe``` and ```Advertise``` actions with given arrow between messages of subscribed and advertised types.
```haskell
class Arrow a => Connect a where
  connect :: (RosBinary b, MsgInfo b, Typeable b,
        RosBinary c, MsgInfo c, Typeable c)
        => TopicName -> TopicName -> a b c -> Node ()
```

This PR contains Subscribe/Advertise instances for ```Topic IO``` and ```TopicArrow IO ()``` types, and Connect instances for ```(->)``` and ```TopicArrow IO```.

Example:
```haskell
main = runNode "n" $ connect "a" "b" vectorLen
```